### PR TITLE
Publish this repository on NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@madetech/marketing-assets",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@madetech/marketing-assets",
+  "version": "1.0.0",
+  "description": "Made Tech marketing assets",
+  "files": [
+    "fonts/**/*.ttf",
+    "logos/**/*.png"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/madetech/marketing-assets.git"
+  },
+  "author": "Made Tech <hello@madetech.com>",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/madetech/marketing-assets/issues"
+  },
+  "homepage": "https://github.com/madetech/marketing-assets#readme"
+}


### PR DESCRIPTION
We now publish reusable assets, primarily logos and fonts, on NPM. This will be useful when creating UI kits for Made Tech branded websites.

These changes allow us to import marketing assets into web sites and applications via NPM. This will enable better reuse across the business on the main site but also learn.madetech.com, p15n.com, etc.